### PR TITLE
Fixes to Work With Rails 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gem
 .bundle
+.project
 Gemfile.lock

--- a/README.rdoc
+++ b/README.rdoc
@@ -19,7 +19,18 @@ Don't forget to <tt>bundle install</tt> to install
 In your environment file <tt>config/environments/development.rb</tt> configure it, and some regular expressions.
 
   config.action_mailer.delivery_method = :safety_mailer
-  SafetyMailer::Config.allowed_matchers = [ /mydomain.com/, /mytestacct@gmail.com/, /super_secret_test/ ]
+  config.action_mailer.safety_mailer_settings = {
+    allowed_matchers: [ /mydomain.com/, /mytestacct@gmail.com/, /super_secret_test/ ],
+    delivery_method: :smtp,
+    delivery_method_settings: {
+      :address => "smtp.mydomain.com",
+      :port => 25,
+      :domain => "mydomain.com",
+      :authentication => :plain,
+      :user_name => "mydomain_mailer@mydomain.com",
+      :password => "password"
+    }
+  }
 
 ... and now, email to anyone@mydomain.com, mytestacct@gmail.com, bob+super_secret_test@yahoo.com all get sent
 and email to other recipients (like the real users in the production database you copied to a test server) is suppressed.
@@ -30,9 +41,10 @@ Any user of the Mail gem can configure safety_mailer:
 
   require "safety_mailer"
   Mail.defaults do
-    delivery_method SafetyMailer::Carrier
+    delivery_method SafetyMailer::Carrier, {
+      ... same settings as above
+    }
   end
-  SafetyMailer::Config.allowed_matchers = [ /mydomain.com/, /mytestacct@gmail.com/, /super_secret_test/ ]
 
 == License
 

--- a/lib/safety_mailer/railtie.rb
+++ b/lib/safety_mailer/railtie.rb
@@ -1,6 +1,6 @@
 module SafetyMailer
   class Railtie < Rails::Railtie
-    initializer "safety_mailer.add_delivery_method" do
+    config.before_configuration do
       ActionMailer::Base.add_delivery_method :safety_mailer, SafetyMailer::Carrier
     end
   end


### PR DESCRIPTION
I couldn't get safety_mailer to work with rails 3.1 so I added some logic to that end. The delivery method wasn't being correctly instantiated (not sure if this has changed recently or was a bug.) Also added some configuration tweaks and updated the docs.
