### PR TITLE
The mail gem expects a delivery method to respond to settings

### DIFF
--- a/lib/safety_mailer/safety_mailer.rb
+++ b/lib/safety_mailer/safety_mailer.rb
@@ -1,10 +1,10 @@
 module SafetyMailer
   class Carrier
-    attr_accessor :params
+    attr_accessor :matchers, :settings
     def initialize(params = {})
-      self.params = params
+      self.matchers = params[:allowed_matchers] || []
+      self.settings = params[:delivery_method_settings] || {}
       delivery_method = params[:delivery_method] || :smtp
-      settings = params[:delivery_method_settings] || {}
       @delivery_method = Mail::Configuration.instance.lookup_delivery_method(delivery_method).new(settings)
     end
     def log(msg)
@@ -12,7 +12,7 @@ module SafetyMailer
     end
     def deliver!(mail)
       mail.to = mail.to.reject do |recipient|
-        if params[:allowed_matchers].any?{ |m| recipient =~ m }
+        if matchers.any?{ |m| recipient =~ m }
           false
         else
           log "*** safety_mailer suppressing mail to #{recipient}"


### PR DESCRIPTION
This [happens after `deliver!` is delegated](https://github.com/mikel/mail/blob/47e288ecfa62cbf73a01f8c40dc39cfb29c3b57b/lib/mail/message.rb#L247), but it causes a `NoMethodError` error to be raised.

I changed the accessors because it seemed confusing to have `params` and `settings` without it being clear which one pertains to the delivery method and which contains settings that are handled by safety_mailer itself.
