### PR TITLE
Sendgrid batch support

### DIFF
--- a/lib/safety_mailer/safety_mailer.rb
+++ b/lib/safety_mailer/safety_mailer.rb
@@ -19,7 +19,7 @@ module SafetyMailer
         return
       end
 
-      mail['X-SMTPAPI'] = prepare_sendgrid_delivery(allowed) if sendgrid?
+      mail['X-SMTPAPI'].value = prepare_sendgrid_delivery(allowed) if sendgrid?
       mail.to = allowed
 
       @delivery_method.deliver!(mail)
@@ -58,7 +58,7 @@ module SafetyMailer
     # by changes to the recipient list. Expects the passed-in Array of
     # addresses to have been whitelist-filtered already.
     def prepare_sendgrid_delivery(addresses)
-      amendments = { :to => addresses }
+      amendments = { 'to' => addresses }
 
       # The SendGrid Substitution Tags feature, if used, requires that an
       # ordered Array of substitution values aligns with the Array of
@@ -76,7 +76,7 @@ module SafetyMailer
           substitutions[template] = values.compact
         end
 
-        amendments[:sub] = substitutions
+        amendments['sub'] = substitutions
       end
 
       JSON.generate(@sendgrid_options.merge(amendments))

--- a/spec/safety_mailer/carrier_spec.rb
+++ b/spec/safety_mailer/carrier_spec.rb
@@ -10,18 +10,75 @@ describe SafetyMailer::Carrier do
     end
   end
 
+  it "prevents mail from going out if no recipient is whitelisted" do
+    Mail::SMTP.any_instance.should_not_receive(:deliver!)
+    SafetyMailer::Carrier.new.deliver!(mail)
+  end
+
   it "strips out unsafe recipients" do
     Mail::SMTP.any_instance.should_receive(:deliver!) do |mail|
       mail.to.should_not include 'mailer@example.com'
       mail.to.should     include 'pop@oozou.com'
     end.once
+
     SafetyMailer::Carrier.new({
       allowed_matchers: [/@oozou\.com$/]
     }).deliver!(mail)
   end
 
-  it "prevents mail from going out if no recipient is whitelisted" do
-    Mail::SMTP.any_instance.should_not_receive(:deliver!)
-    SafetyMailer::Carrier.new.deliver!(mail)
+  context "with irrelevant SendGrid headers" do
+    let(:mail) do
+      Mail.new do
+        from    'safety@example.com'
+        to      'mailer@example.com, pop@oozou.com'
+        subject "Angry Birds Star Wars"
+        body    "Lorem ipsum dolor sit amet"
+      end.tap do |m|
+        m['X-SMTPAPI'] = stub(value: '{}')
+      end
+    end
+
+    it "ignores SendGrid headers, strips out unsafe recipients" do
+      Mail::SMTP.any_instance.should_receive(:deliver!) do |mail|
+        mail.to.should_not include 'mailer@example.com'
+        mail.to.should     include 'pop@oozou.com'
+      end.once
+
+      SafetyMailer::Carrier.new({
+        allowed_matchers: [/@oozou\.com$/]
+      }).deliver!(mail)
+    end
+  end
+
+  context "with SendGrid batch mailing" do
+    let(:mail) do
+      Mail.new do
+        from    'safety@example.com'
+        subject "Lunch Order"
+        body    "You like -food-"
+      end.tap do |m|
+        sendgrid = {
+          'to'  => ['mailer@example.com', 'pop@oozou.com'],
+          'sub' => { '-food-' => ['bagels', 'sushi'] }
+        }
+        m['X-SMTPAPI'] = JSON.generate(sendgrid)
+      end
+    end
+
+    it "strips out unsafe recipients and corresponding substitutions" do
+      Mail::SMTP.any_instance.should_receive(:deliver!) do |mail|
+        recipients = JSON.parse(mail['X-SMTPAPI'].value)['to']
+        recipients.should_not include 'mailer@example.com'
+        recipients.should     include 'pop@oozou.com'
+
+        substitutions = JSON.parse(mail['X-SMTPAPI'].value)['sub']
+        substitutions['-food-'].should_not include 'bagels'
+        substitutions['-food-'].should     include 'sushi'
+      end.once
+
+      SafetyMailer::Carrier.new({
+        allowed_matchers: [/@oozou\.com$/]
+      }).deliver!(mail)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'bundler/setup'
 require 'safety_mailer'
 require 'mail'
+require 'json'
 
 RSpec.configure do |config|
 end


### PR DESCRIPTION
Hey there,

I'm not sure if you'd deem this as being of general interest for `safety_mailer` users, but @scomma and I have implemented support for use with [the SendGrid API](http://docs.sendgrid.com/documentation/api/smtp-api/developers-guide/), so that batch mailings are handled by `safety_mailer`'s whitelists. It could surely do with having some specs since the complexity has grown, so I'd be happy to add some and perhaps move it out to another module if you'd prefer, if there's interest in integrating this.
