### PR TITLE
Remove disallowed recipients from CC/BCC fields too. Make Carrier#deliver! behave like original #deliver!: raise an exception when there're no recipients initially and return mail object.

### DIFF
--- a/lib/safety_mailer/safety_mailer.rb
+++ b/lib/safety_mailer/safety_mailer.rb
@@ -1,30 +1,52 @@
 module SafetyMailer
   class Carrier
-    attr_accessor :matchers, :settings
+    attr_accessor :allowed_matchers, :settings
+
     def initialize(params = {})
-      self.matchers = params[:allowed_matchers] || []
+      self.allowed_matchers = params[:allowed_matchers] || []
       self.settings = params[:delivery_method_settings] || {}
       delivery_method = params[:delivery_method] || :smtp
       @delivery_method = Mail::Configuration.instance.lookup_delivery_method(delivery_method).new(settings)
     end
-    def log(msg)
-      Rails.logger.warn(msg) if defined?(Rails)
-    end
+
     def deliver!(mail)
-      mail.to = mail.to.reject do |recipient|
-        if matchers.any?{ |m| recipient =~ m }
-          false
-        else
-          log "*** safety_mailer suppressing mail to #{recipient}"
-          true
-        end
+      original_recipients = Array(mail.to).
+        concat(Array(mail.cc)).
+        concat(Array(mail.bcc))
+      if original_recipients.empty?
+        raise ArgumentError, "At least one recipient (To, Cc or Bcc) is required to send a message"
       end
-      if mail.to.nil? || mail.to.empty?
-        log "*** safety_mailer - no recipients left ... suppressing delivery altogether"
+
+      remove_disallowed_recipients!(mail)
+
+      allowed_recipients = mail.to.dup.
+        concat(mail.cc).
+        concat(mail.bcc)
+
+      if allowed_recipients.empty?
+        log "safety_mailer: no allowed recipients. Suppressing delivery"
+        mail
       else
-        log "*** safety_mailer allowing delivery to #{mail.to}"
+        log "safety_mailer: allowing delivery to #{allowed_recipients}"
+        log "safety_mailer: original email below:"
         @delivery_method.deliver!(mail)
       end
+    end
+
+    private
+
+    def remove_disallowed_recipients!(mail)
+      recipient_allowed = lambda { |recipient|
+        allowed_matchers.any? { |m| recipient =~ m }
+      }
+
+      mail.to = Array(mail.to).select(&recipient_allowed)
+      mail.cc = Array(mail.cc).select(&recipient_allowed)
+      mail.bcc = Array(mail.bcc).select(&recipient_allowed)
+    end
+
+    def log(msg)
+      Rails.logger.warn(msg) if defined?(Rails)
     end
   end
 end


### PR DESCRIPTION
Hi,

I've made some changes to remove CC/BCC recipients that shouldn't receive emails. I've also made a couple of other changes, especially to make it quack like the original #deliver! method. Let me know if you're willing to merge this.

BTW are there any tests/specs? Would you accept a pull request with them?

Greetings,
Wojciech
