### PR TITLE
Allow recipients to be blank

### DIFF
--- a/lib/safety_mailer/safety_mailer.rb
+++ b/lib/safety_mailer/safety_mailer.rb
@@ -30,7 +30,7 @@ module SafetyMailer
     def recipients
       sendgrid?
       sendgrid_to = @sendgrid_options['to']
-      sendgrid_to.nil? || sendgrid_to.empty? ? mail.to : sendgrid_to
+      sendgrid_to.nil? || sendgrid_to.empty? ? mail.to : sendgrid_to || []
     end
 
     def sendgrid?


### PR DESCRIPTION
Was barfing when the 'to' field was empty i.e. when only using bcc.
